### PR TITLE
Loosen dependency on ActiveRecord to minor version

### DIFF
--- a/oauth2-provider.gemspec
+++ b/oauth2-provider.gemspec
@@ -14,7 +14,7 @@ spec = Gem::Specification.new do |s|
 
   s.add_dependency('activerecord', ENV['RAILS_VERSION'] || '~> 4.0')
   s.add_dependency('protected_attributes', '~>1.0.0')
-  s.add_dependency('bcrypt')
+  s.add_dependency('bcrypt', '~> 3.1')
   s.add_dependency('json')
   s.add_dependency('rack')
 

--- a/oauth2-provider.gemspec
+++ b/oauth2-provider.gemspec
@@ -12,7 +12,7 @@ spec = Gem::Specification.new do |s|
   s.files             = %w(README.rdoc) + Dir.glob("{spec,lib,example}/**/*")
   s.require_paths     = ["lib"]
 
-  s.add_dependency('activerecord', ENV['RAILS_VERSION'] || '~>4.0.0')
+  s.add_dependency('activerecord', ENV['RAILS_VERSION'] || '~> 4.0')
   s.add_dependency('protected_attributes', '~>1.0.0')
   s.add_dependency("bcrypt-ruby")
   s.add_dependency("json")

--- a/oauth2-provider.gemspec
+++ b/oauth2-provider.gemspec
@@ -1,26 +1,26 @@
 spec = Gem::Specification.new do |s|
-  s.name              = "oauth2-provider"
+  s.name              = 'oauth2-provider'
   s.version           = '2.0.0'
-  s.summary           = "Simple OAuth 2.0 provider toolkit"
-  s.author            = "James Coglan"
-  s.email             = "james@songkick.com"
-  s.homepage          = "http://www.songkick.com"
+  s.summary           = 'Simple OAuth 2.0 provider toolkit'
+  s.author            = 'James Coglan'
+  s.email             = 'james@songkick.com'
+  s.homepage          = 'http://www.songkick.com'
 
   s.extra_rdoc_files  = %w(README.rdoc)
   s.rdoc_options      = %w(--main README.rdoc)
 
   s.files             = %w(README.rdoc) + Dir.glob("{spec,lib,example}/**/*")
-  s.require_paths     = ["lib"]
+  s.require_paths     = ['lib']
 
   s.add_dependency('activerecord', ENV['RAILS_VERSION'] || '~> 4.0')
   s.add_dependency('protected_attributes', '~>1.0.0')
-  s.add_dependency("bcrypt-ruby")
-  s.add_dependency("json")
-  s.add_dependency("rack")
+  s.add_dependency('bcrypt')
+  s.add_dependency('json')
+  s.add_dependency('rack')
 
-  s.add_development_dependency("rspec", "~> 3.3.0")
-  s.add_development_dependency("sqlite3")
-  s.add_development_dependency("sinatra", ">= 1.3.0")
-  s.add_development_dependency("thin")
-  s.add_development_dependency("factory_girl", "~> 2.0")
+  s.add_development_dependency('rspec', '~> 3.3.0')
+  s.add_development_dependency('sqlite3')
+  s.add_development_dependency('sinatra', '>= 1.3.0')
+  s.add_development_dependency('thin')
+  s.add_development_dependency('factory_girl', '~> 2.0')
 end


### PR DESCRIPTION
@jdoconnor I think we're just going to use our own version of the oauth2 gem, since it looks like songkick, while they are maintaining their repo, haven't done a release in over 3 years. This PR just loosens the dependency on ActiveRecord to the minor version (~> 4.0)