### PR TITLE
Expose authorization instance variable

### DIFF
--- a/lib/oauth2/provider/exchange.rb
+++ b/lib/oauth2/provider/exchange.rb
@@ -2,7 +2,7 @@ module OAuth2
   class Provider
 
     class Exchange
-      attr_reader :client, :error, :error_description
+      attr_reader :client, :error, :error_description, :authorization
 
       REQUIRED_PARAMS    = [CLIENT_ID, CLIENT_SECRET, GRANT_TYPE]
       VALID_GRANT_TYPES  = [AUTHORIZATION_CODE, PASSWORD, ASSERTION, REFRESH_TOKEN, CLIENT_CREDENTIALS]


### PR DESCRIPTION
Added an `attr_reader` to exchange.rb to expose the `@authorization` instance variable. This also includes the changes from [this PR](https://github.com/lumoslabs/oauth2-provider/pull/6) which has been open for quite a while.

@lumoslabs/platform 